### PR TITLE
Changing tar command

### DIFF
--- a/mkstage4.sh
+++ b/mkstage4.sh
@@ -145,7 +145,7 @@ then
   echo "example: \$ `basename $0` -s /my-backup --exclude=/etc/ssh/ssh_host*"
   echo ""
   echo "COMMAND LINE PREVIEW:"
-  echo "cd $TARGET && tar $TAR_OPTIONS $STAGE4_FILENAME * $EXCLUDES $OPTIONS"
+  echo "cd $TARGET && tar $TAR_OPTIONS $EXCLUDES $OPTIONS $STAGE4_FILENAME *"
   echo ""
   echo -n "Type \"yes\" to continue or anything else to quit: "
   read AGREE
@@ -154,7 +154,7 @@ fi
 # start stage4 creation:
 if [ "$AGREE" == "yes" ]
 then
-  cd $TARGET && tar $TAR_OPTIONS $STAGE4_FILENAME * $EXCLUDES $OPTIONS
+  cd $TARGET && tar $TAR_OPTIONS $EXCLUDES $OPTIONS $STAGE4_FILENAME * 
 fi
 
 exit 0


### PR DESCRIPTION
I'm currently installing Gentoo on a new machine and I use your very nice script.
I was using a live USB based on Debian to install Gentoo and I ran into a problem with the order of the options: the tar command silently failed and did not take into account the exclude dirs. By changing the order of the options on the command line, everything went fine.