### PR TITLE
adding prefix

### DIFF
--- a/mkstage4.sh
+++ b/mkstage4.sh
@@ -96,18 +96,18 @@ shift;OPTIONS="$@"
 
 # Excludes:
 EXCLUDES="\
---exclude=home/*/.bash_history \
---exclude=dev/* \
---exclude=media/* \
---exclude=mnt/*/* \
---exclude=proc/* \
---exclude=run/* \
---exclude=sys/* \
---exclude=tmp/* \
---exclude=usr/portage/* \
---exclude=var/lock/* \
---exclude=var/log/* \
---exclude=var/run/*"
+--exclude=${TARGET}/home/*/.bash_history \
+--exclude=${TARGET}/dev/* \
+--exclude=${TARGET}/media/* \
+--exclude=${TARGET}/mnt/*/* \
+--exclude=${TARGET}/proc/* \
+--exclude=${TARGET}/run/* \
+--exclude=${TARGET}/sys/* \
+--exclude=${TARGET}/tmp/* \
+--exclude=${TARGET}/usr/portage/* \
+--exclude=${TARGET}/var/lock/* \
+--exclude=${TARGET}/var/log/* \
+--exclude=${TARGET}/var/run/*"
 
 if [ "$TARGET" == "/" ]
 then
@@ -116,12 +116,12 @@ fi
 
 if [ ${EXCLUDE_CONNMAN} -eq 1 ]
 then
-  EXCLUDES+=" --exclude=var/lib/connman/*"
+  EXCLUDES+=" --exclude=${TARGET}/var/lib/connman/*"
 fi
 
 if [ ${EXCLUDE_BOOT} -eq 1 ]
 then
-  EXCLUDES+=" --exclude=boot/*"
+  EXCLUDES+=" --exclude=${TARGET}/boot/*"
 fi
 
 if [ ${EXCLUDE_LOST} -eq 1 ]

--- a/mkstage4.sh
+++ b/mkstage4.sh
@@ -145,7 +145,7 @@ then
   echo "example: \$ `basename $0` -s /my-backup --exclude=/etc/ssh/ssh_host*"
   echo ""
   echo "COMMAND LINE PREVIEW:"
-  echo "cd $TARGET && tar $TAR_OPTIONS $EXCLUDES $OPTIONS $STAGE4_FILENAME *"
+  echo "cd $TARGET && tar $TAR_OPTIONS $EXCLUDES $OPTIONS -f $STAGE4_FILENAME *"
   echo ""
   echo -n "Type \"yes\" to continue or anything else to quit: "
   read AGREE
@@ -154,7 +154,7 @@ fi
 # start stage4 creation:
 if [ "$AGREE" == "yes" ]
 then
-  cd $TARGET && tar $TAR_OPTIONS $EXCLUDES $OPTIONS -f $STAGE4_FILENAME * 
+  cd $TARGET && tar $TAR_OPTIONS $EXCLUDES $OPTIONS -f $STAGE4_FILENAME *
 fi
 
 exit 0

--- a/mkstage4.sh
+++ b/mkstage4.sh
@@ -154,7 +154,7 @@ fi
 # start stage4 creation:
 if [ "$AGREE" == "yes" ]
 then
-  cd $TARGET && tar $TAR_OPTIONS $EXCLUDES $OPTIONS -f $STAGE4_FILENAME *
+  tar $TAR_OPTIONS -f $STAGE4_FILENAME * $EXCLUDES $OPTIONS
 fi
 
 exit 0

--- a/mkstage4.sh
+++ b/mkstage4.sh
@@ -130,7 +130,7 @@ then
 fi
 
 # Generic tar options:
-TAR_OPTIONS="-cjpP --ignore-failed-read -f"
+TAR_OPTIONS="-cjpP --ignore-failed-read"
 
 # if not in quiet mode, this message will be displayed:
 if [ "$AGREE" != "yes" ]
@@ -154,7 +154,7 @@ fi
 # start stage4 creation:
 if [ "$AGREE" == "yes" ]
 then
-  cd $TARGET && tar $TAR_OPTIONS $EXCLUDES $OPTIONS $STAGE4_FILENAME * 
+  cd $TARGET && tar $TAR_OPTIONS $EXCLUDES $OPTIONS -f $STAGE4_FILENAME * 
 fi
 
 exit 0


### PR DESCRIPTION
During an installation (explained in the other PR), I ran in a delicate issue. After restoring the archive, the system is functional but there is a caveat with the option --exclude=sys/*. This excludes files from glibc (/usr/include/sys/) and gcc could not produce executable files, emerge is broken.
This PR proposes a quick fix, that is to prefix all exclude dirs by the $TARGET dir.