### PR TITLE
add -k option to allow user separately saving current kernel modules and src

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ The script is a new edition of an earlier [mkstage4 script](https://github.com/g
  
 More information on mkstage4 can be found on its own Chymeric Tutorials article: [mkstage4 - Stage 4 Tarballs Made Easy](http://tutorials.chymera.eu/blog/2014/05/18/mkstage4-stage4-tarballs-made-easy/). 
 
+Chinese Introduction [中文说明](http://liuk.io/blog/gentoo-stage4)
+
 ## Installation
 
 The script can be run directly from its containing folder (and thus, is installed simply by downloading or cloning it from here - and adding run permissions):
@@ -48,10 +50,36 @@ Command line arguments:
   -l: excludes lost+found directory.
   -e: an additional excludes directory (one dir one -e).
   -s: makes tarball of current system.
-  -k: separately save current kernel moudules and src (smaller).
+  -k: separately save current kernel modules and src (smaller & save decompression time).
   -t: makes tarball of system located at the <target-mountpoint>.
   -h: displays help message.
 ```
+
+eg.
+```bash
+liuk@localhost ~/proj/mkstage4 $ sudo ./mkstage4.sh -l -s -k -e /dataA -e /home/liuk/dataZ1/ /dataB/gentoo-stage4-20180511 --exclude=/dataB/* --exclude=/ssd/*
+Are you sure that you want to make a stage 4 tarball of the system
+located under the following directory?
+/
+
+WARNING: since all data is saved by default the user should exclude all
+security- or privacy-related files and directories, which are not
+already excluded by mkstage4 options (such as -c), manually per cmdline.
+example: $ mkstage4.sh -s /my-backup --exclude=/etc/ssh/ssh_host*
+
+COMMAND LINE PREVIEW:
+tar -cjpP --ignore-failed-read --exclude=/home/*/.bash_history --exclude=/dev/* --exclude=/var/tmp/* --exclude=/media/* --exclude=/mnt/*/* --exclude=/proc/* --exclude=/run/* --exclude=/sys/* --exclude=/tmp/* --exclude=/usr/portage/* --exclude=/var/lock/* --exclude=/var/log/* --exclude=/var/run/* --exclude=/dataA --exclude=/home/liuk/dataZ1/ --exclude=/usr/src/*  --exclude=/lib64/modules/*  --exclude=dataB/gentoo-stage4-20180511.tar.bz2 --exclude=lost+found --exclude=/dataB/* --exclude=/ssd/* -f /dataB/gentoo-stage4-20180511.tar.bz2 /*
+
+tar -cjpP --ignore-failed-read -f /dataB/gentoo-stage4-20180511.tar.bz2.ksrc /usr/src/linux-4.16.6-gentoo*
+
+tar -cjpP --ignore-failed-read -f /dataB/gentoo-stage4-20180511.tar.bz2.kmod /lib64/modules/4.16.6-gentoo*
+
+Type "yes" to continue or anything else to quit: yes
+```
+
+### -k separately save current kernel modules and src
+
+  It will save current running kernel modules and src in separate tar file. It save decompression time.
 
 ## Extract Tarball
 
@@ -59,6 +87,13 @@ Tarballs created with mkstage4 can be extracted with:
 
 ```bash
 tar xvjpf archive_name.tar.bz2
+```
+
+If you use -k option, extract src & modules separately
+
+```bash
+tar xvjpf archive_name.tar.bz2.kmod
+tar xvjpf archive_name.tar.bz2.ksrc
 ```
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -41,12 +41,14 @@ mkstage4 -t /custom/mount/point archive_name
 Command line arguments:
 
 ```
-mkstage4 [-q -c -b] [-s || -t <target-mountpoint>] <archive-filename> [custom-tar-options]
+  mkstage4.sh [-q -c -b -l -k] [-s || -t <target-mountpoint>] [-e <additional excludes dir*>] <archive-filename> [custom-tar-options]
   -q: activates quiet mode (no confirmation).
   -c: excludes connman network lists.
   -b: excludes boot directory.
   -l: excludes lost+found directory.
+  -e: an additional excludes directory (one dir one -e).
   -s: makes tarball of current system.
+  -k: separately save current kernel moudules and src (smaller).
   -t: makes tarball of system located at the <target-mountpoint>.
   -h: displays help message.
 ```

--- a/README.md
+++ b/README.md
@@ -55,32 +55,6 @@ Command line arguments:
   -h: displays help message.
 ```
 
-eg.
-```bash
-liuk@localhost ~/proj/mkstage4 $ sudo ./mkstage4.sh -l -s -k -e /dataA -e /home/liuk/dataZ1/ /dataB/gentoo-stage4-20180511 --exclude=/dataB/* --exclude=/ssd/*
-Are you sure that you want to make a stage 4 tarball of the system
-located under the following directory?
-/
-
-WARNING: since all data is saved by default the user should exclude all
-security- or privacy-related files and directories, which are not
-already excluded by mkstage4 options (such as -c), manually per cmdline.
-example: $ mkstage4.sh -s /my-backup --exclude=/etc/ssh/ssh_host*
-
-COMMAND LINE PREVIEW:
-tar -cjpP --ignore-failed-read --exclude=/home/*/.bash_history --exclude=/dev/* --exclude=/var/tmp/* --exclude=/media/* --exclude=/mnt/*/* --exclude=/proc/* --exclude=/run/* --exclude=/sys/* --exclude=/tmp/* --exclude=/usr/portage/* --exclude=/var/lock/* --exclude=/var/log/* --exclude=/var/run/* --exclude=/dataA --exclude=/home/liuk/dataZ1/ --exclude=/usr/src/*  --exclude=/lib64/modules/*  --exclude=dataB/gentoo-stage4-20180511.tar.bz2 --exclude=lost+found --exclude=/dataB/* --exclude=/ssd/* -f /dataB/gentoo-stage4-20180511.tar.bz2 /*
-
-tar -cjpP --ignore-failed-read -f /dataB/gentoo-stage4-20180511.tar.bz2.ksrc /usr/src/linux-4.16.6-gentoo*
-
-tar -cjpP --ignore-failed-read -f /dataB/gentoo-stage4-20180511.tar.bz2.kmod /lib64/modules/4.16.6-gentoo*
-
-Type "yes" to continue or anything else to quit: yes
-```
-
-### -k separately save current kernel modules and src
-
-  It will save current running kernel modules and src in separate tar file. It save decompression time.
-
 ## Extract Tarball
 
 Tarballs created with mkstage4 can be extracted with:

--- a/mkstage4.sh
+++ b/mkstage4.sh
@@ -25,9 +25,9 @@ USAGE="usage:\n\
   -c: excludes connman network lists.\n\
   -b: excludes boot directory.\n\
   -l: excludes lost+found directory.\n\
-  -e: an additional excludes directory (one dir one -e).\n\
+  -e: an additional excludes directory (one dir one -e, donot use it with *).\n\
   -s: makes tarball of current system.\n\
-  -k: separately save current kernel moudules and src (smaller).\n\
+  -k: separately save current kernel modules and src (smaller & save decompression time).\n\
   -t: makes tarball of system located at the <target-mountpoint>.\n\
   -h: displays help message."
 
@@ -117,7 +117,7 @@ shift;OPTIONS="$@"
 
 if [ ${S_KERNEL} -eq 1 ]
 then
-  USER_EXCL+=" --exclude=${TARGET}/usr/src/* "
+  USER_EXCL+=" --exclude=${TARGET}usr/src/* "
   if [ ${x86_64} -eq 1 ]
   then
       USER_EXCL+=" --exclude=${TARGET}lib64/modules/* "
@@ -182,6 +182,19 @@ then
   echo ""
   echo "COMMAND LINE PREVIEW:"
   echo "tar $TAR_OPTIONS $EXCLUDES $OPTIONS -f $STAGE4_FILENAME ${TARGET}*"
+  if [ ${S_KERNEL} -eq 1 ]
+  then
+    echo ""
+    echo  "tar $TAR_OPTIONS -f $STAGE4_FILENAME.ksrc ${TARGET}usr/src/linux-$(uname -r)*"
+    if [ ${x86_64} -eq 1 ]
+    then
+        echo ""
+        echo  "tar $TAR_OPTIONS -f $STAGE4_FILENAME.kmod ${TARGET}lib64/modules/$(uname -r)*"
+    else
+        echo ""
+        echo  "tar $TAR_OPTIONS -f $STAGE4_FILENAME.kmod ${TARGET}lib/modules/$(uname -r)*"
+    fi    
+  fi
   echo ""
   echo -n "Type \"yes\" to continue or anything else to quit: "
   read AGREE
@@ -193,12 +206,12 @@ then
   tar $TAR_OPTIONS $EXCLUDES $OPTIONS -f $STAGE4_FILENAME ${TARGET}*
   if [ ${S_KERNEL} -eq 1 ]
   then
-    tar $TAR_OPTIONS $OPTIONS -f ksrc_$STAGE4_FILENAME ${TARGET}usr/src/linux-$(uname -r)*
+    tar $TAR_OPTIONS -f $STAGE4_FILENAME.ksrc ${TARGET}usr/src/linux-$(uname -r)*
     if [ ${x86_64} -eq 1 ]
     then
-        tar $TAR_OPTIONS $OPTIONS -f kmod_$STAGE4_FILENAME ${TARGET}lib64/modules/$(uname -r)*
+        tar $TAR_OPTIONS -f $STAGE4_FILENAME.kmod ${TARGET}lib64/modules/$(uname -r)*
     else
-        tar $TAR_OPTIONS $OPTIONS -f kmod_$STAGE4_FILENAME ${TARGET}lib/modules/$(uname -r)*
+        tar $TAR_OPTIONS -f $STAGE4_FILENAME.kmod ${TARGET}lib/modules/$(uname -r)*
     fi    
     
   fi

--- a/mkstage4.sh
+++ b/mkstage4.sh
@@ -12,18 +12,27 @@ EXCLUDE_BOOT=0
 EXCLUDE_CONNMAN=0
 EXCLUDE_LOST=0
 QUIET=0
+USER_EXCL=""
+S_KERNEL=0
+x86_64=0
+if [ `getconf LONG_BIT` = "64" ]
+then
+    x86_64=1
+fi
 USAGE="usage:\n\
-  `basename $0` [-q -c -b] [-s || -t <target-mountpoint>] <archive-filename> [custom-tar-options]\n\
+  `basename $0` [-q -c -b -l -k] [-s || -t <target-mountpoint>] [-e <additional excludes dir*>] <archive-filename> [custom-tar-options]\n\
   -q: activates quiet mode (no confirmation).\n\
   -c: excludes connman network lists.\n\
   -b: excludes boot directory.\n\
   -l: excludes lost+found directory.\n\
+  -e: an additional excludes directory (one dir one -e).\n\
   -s: makes tarball of current system.\n\
+  -k: separately save current kernel moudules and src (smaller).\n\
   -t: makes tarball of system located at the <target-mountpoint>.\n\
   -h: displays help message."
 
 # reads options:
-while getopts ':t:sqcblh' flag; do
+while getopts ':te:skqcblh' flag; do
   case "${flag}" in
     t)
       TARGET="$OPTARG"
@@ -34,6 +43,9 @@ while getopts ':t:sqcblh' flag; do
     q)
       QUIET=1
       ;;
+    k)
+      S_KERNEL=1
+      ;;      
     c)
       EXCLUDE_CONNMAN=1
       ;;
@@ -43,6 +55,9 @@ while getopts ':t:sqcblh' flag; do
     l)
       EXCLUDE_LOST=1
       ;;
+    e)
+    USER_EXCL+=" --exclude=${OPTARG}"
+    ;;
     h)
       echo -e "$USAGE"
       exit 0
@@ -100,10 +115,23 @@ fi
 #Shifts pointer to read custom tar options
 shift;OPTIONS="$@"
 
+if [ ${S_KERNEL} -eq 1 ]
+then
+  USER_EXCL+=" --exclude=${TARGET}/usr/src/* "
+  if [ ${x86_64} -eq 1 ]
+  then
+      USER_EXCL+=" --exclude=${TARGET}lib64/modules/* "
+  else
+      USER_EXCL+=" --exclude=${TARGET}lib/modules/* "
+  fi
+fi
+
+
 # Excludes:
 EXCLUDES="\
 --exclude=${TARGET}home/*/.bash_history \
 --exclude=${TARGET}dev/* \
+--exclude=${TARGET}var/tmp/* \
 --exclude=${TARGET}media/* \
 --exclude=${TARGET}mnt/*/* \
 --exclude=${TARGET}proc/* \
@@ -114,6 +142,8 @@ EXCLUDES="\
 --exclude=${TARGET}var/lock/* \
 --exclude=${TARGET}var/log/* \
 --exclude=${TARGET}var/run/*"
+
+EXCLUDES+=$USER_EXCL
 
 if [ "$TARGET" == "/" ]
 then
@@ -161,6 +191,17 @@ fi
 if [ "$AGREE" == "yes" ]
 then
   tar $TAR_OPTIONS $EXCLUDES $OPTIONS -f $STAGE4_FILENAME ${TARGET}*
+  if [ ${S_KERNEL} -eq 1 ]
+  then
+    tar $TAR_OPTIONS $OPTIONS -f ksrc_$STAGE4_FILENAME ${TARGET}usr/src/linux-$(uname -r)*
+    if [ ${x86_64} -eq 1 ]
+    then
+        tar $TAR_OPTIONS $OPTIONS -f kmod_$STAGE4_FILENAME ${TARGET}lib64/modules/$(uname -r)*
+    else
+        tar $TAR_OPTIONS $OPTIONS -f kmod_$STAGE4_FILENAME ${TARGET}lib/modules/$(uname -r)*
+    fi    
+    
+  fi
 fi
 
 exit 0


### PR DESCRIPTION
The patch automatically excludes unnecessary kernel source and modules for gentoo system, which usually contain lots of small files.