### PR TITLE
exclude /var/lib/docker , causes issues on unpack

### DIFF
--- a/mkstage4.sh
+++ b/mkstage4.sh
@@ -141,7 +141,9 @@ EXCLUDES="\
 --exclude=${TARGET}usr/portage/* \
 --exclude=${TARGET}var/lock/* \
 --exclude=${TARGET}var/log/* \
---exclude=${TARGET}var/run/*"
+--exclude=${TARGET}var/run/* \
+--exclude=${TARGET}var/lib/docker/*"
+
 
 EXCLUDES+=$USER_EXCL
 


### PR DESCRIPTION
If /var/lib/docker is included in the image it will cause unpack to fail by filling entire volume. 
Since it contains the device-mapper overlays.
Might be enough to just exclude /var/lib/docker/image, but I did not test that. 