### PR TITLE
Loop through excludes

### DIFF
--- a/mkstage4.sh
+++ b/mkstage4.sh
@@ -147,7 +147,9 @@ EXCLUDES="\
 --exclude=${TARGET}var/lock/* \
 --exclude=${TARGET}var/log/* \
 --exclude=${TARGET}var/run/* \
---exclude=${TARGET}var/lib/docker/*"
+--exclude=${TARGET}var/lib/docker/* \
+--exclude=${TARGET}var/db/repos/gentoo/* \
+--exclude=${TARGET}var/cache/distfiles/*"
 
 
 EXCLUDES+=$USER_EXCL


### PR DESCRIPTION
Added a loop to auto-generate --exclude=${TARGET} options for tar.
Left excludes list multi-line for better usage of diff.
Added static portage excludes as multi-line.