### PR TITLE
Check user excludes sanity

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ cd /your/mkstage4/directory
 chmod +x mkstage4.sh
 ```
 
-For [Gentoo Linux](http://en.wikipedia.org/wiki/Gentoo_linux) and [Derivatives](http://en.wikipedia.org/wiki/Category:Gentoo_Linux_derivatives), mkstage4 is also available in [Portage](http://en.wikipedia.org/wiki/Portage_(software)) via the *[chymeric overlay](https://github.com/TheChymera/chymeric)* (which can be enabled with just two commands, as seen in [the README](https://github.com/TheChymera/chymeric)).
-After you have enabled the overlay, just run the following command:
+For [Gentoo Linux](http://en.wikipedia.org/wiki/Gentoo_linux) and [Derivatives](http://en.wikipedia.org/wiki/Category:Gentoo_Linux_derivatives), mkstage4 is also available in [Portage](http://en.wikipedia.org/wiki/Portage_(software)) via the base Gentoo overlay.
+On any Gentoo system, just run the following command:
 
 ```
 emerge app-backup/mkstage4

--- a/mkstage4.sh
+++ b/mkstage4.sh
@@ -34,7 +34,7 @@ USAGE="usage:\n\
   -h: displays help message."
 
 # reads options:
-while getopts ':te:skqcblph' flag; do
+while getopts ':t:e:skqcblph' flag; do
   case "${flag}" in
     t)
       TARGET="$OPTARG"

--- a/mkstage4.sh
+++ b/mkstage4.sh
@@ -13,6 +13,7 @@ EXCLUDE_CONNMAN=0
 EXCLUDE_LOST=0
 QUIET=0
 USER_EXCL=""
+USER_EXCL_FAILED=""
 S_KERNEL=0
 x86_64=0
 PARALLEL=0
@@ -65,7 +66,12 @@ while getopts ':t:e:skqcblph' flag; do
       EXCLUDE_LOST=1
       ;;
     e)
-      USER_EXCL+=" --exclude=${OPTARG}"
+      if [ -e ${OPTARG} ]
+      then
+        USER_EXCL+=" --exclude=${OPTARG}"
+      else
+        USER_EXCL_FAILED+="${OPTARG} "
+      fi
       ;;
     p)
       PARALLEL=1
@@ -204,6 +210,20 @@ then
   fi
 else
   TAR_OPTIONS+=" -j"
+fi
+
+if [ -n  "$USER_EXCL_FAILED" ]
+then
+  echo -e "\e[33;1mWARNING:\e[0;1m Following user-specified exclude object(s) were not found: \e[0m${USER_EXCL_FAILED}"
+  echo "Continue anyway?"
+  echo -n "Type \"yes\" to continue or anything else to quit: "
+  read AGREE_MISMATCH
+  if [ "$AGREE_MISMATCH" != "yes" ]
+  then
+	exit 0
+  else
+	echo ""
+  fi
 fi
 
 # if not in quiet mode, this message will be displayed:


### PR DESCRIPTION
The user excludes list generated by adding -e /foo/ to the parameters can have typos made by the user.
This commit will display a warning on what was not found (even in quiet mode) and ask the user to confirm this is intended.