### PR TITLE
Clean up based on Shellcheck recommendations

### DIFF
--- a/mkstage4.sh
+++ b/mkstage4.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # checks if run as root:
-if ! [ "`whoami`" == "root" ]
+if [ "$(whoami)" != "root" ]
 then
-  echo "`basename $0`: must be root."
+  echo "$(basename "$0"): must be root."
   exit 1
 fi
 
@@ -12,23 +12,23 @@ EXCLUDE_BOOT=0
 EXCLUDE_CONNMAN=0
 EXCLUDE_LOST=0
 QUIET=0
-USER_EXCL=""
+USER_EXCL=()
 S_KERNEL=0
 x86_64=0
 PARALLEL=0
 HAS_PORTAGEQ=0
 
-if [ `which portageq` ]
+if command -v portageq &>/dev/null
 then
   HAS_PORTAGEQ=1
 fi
 
-if [ `getconf LONG_BIT` = "64" ]
+if [ "$(getconf LONG_BIT)" == "64" ]
 then
     x86_64=1
 fi
 USAGE="usage:\n\
-  `basename $0` [-q -c -b -l -k -p] [-s || -t <target-mountpoint>] [-e <additional excludes dir*>] <archive-filename> [custom-tar-options]\n\
+  $(basename "$0") [-q -c -b -l -k -p] [-s || -t <target-mountpoint>] [-e <additional excludes dir*>] <archive-filename> [custom-tar-options]\n\
   -q: activates quiet mode (no confirmation).\n\
   -c: excludes connman network lists.\n\
   -b: excludes boot directory.\n\
@@ -41,8 +41,9 @@ USAGE="usage:\n\
   -h: displays help message."
 
 # reads options:
-while getopts ':t:e:skqcblph' flag; do
-  case "${flag}" in
+while getopts ":t:e:skqcblph" flag
+do
+  case "$flag" in
     t)
       TARGET="$OPTARG"
       ;;
@@ -65,7 +66,7 @@ while getopts ':t:e:skqcblph' flag; do
       EXCLUDE_LOST=1
       ;;
     e)
-      USER_EXCL+=" --exclude=${OPTARG}"
+      USER_EXCL+=("--exclude=${OPTARG}")
       ;;
     p)
       PARALLEL=1
@@ -85,129 +86,132 @@ while getopts ':t:e:skqcblph' flag; do
   esac
 done
 
-if [ "$TARGET" == "" ]
+if [ -z "$TARGET" ]
 then
-  echo "`basename $0`: no target specified."
+  echo "$(basename "$0"): no target specified."
   echo -e "$USAGE"
   exit 1
 fi
 
 # make sure TARGET path ends with slash
-if [ "`echo $TARGET | grep -c '\/$'`" -le "0" ]
+if [[ "$TARGET" != */  ]]
 then
   TARGET="${TARGET}/"
 fi
 
 # shifts pointer to read mandatory output file specification
-shift $(($OPTIND - 1))
+shift $((OPTIND - 1))
 ARCHIVE=$1
 
 # checks for correct output file specification
-if [ "$ARCHIVE" == "" ]
+if [ -z "$ARCHIVE" ]
 then
-  echo "`basename $0`: no archive file name specified."
+  echo "$(basename "$0"): no archive file name specified."
   echo -e "$USAGE"
   exit 1
 fi
 
 # checks for quiet mode (no confirmation)
-if [ ${QUIET} -eq 1 ]
+if ((QUIET == 1))
 then
   AGREE="yes"
 fi
 
 # determines if filename was given with relative or absolute path
-if [ "`echo $ARCHIVE | grep -c '^\/'`" -gt "0" ]
+if (($(grep -c '^\/' <<< "$ARCHIVE") > 0));
 then
   STAGE4_FILENAME="${ARCHIVE}.tar.bz2"
 else
-  STAGE4_FILENAME="`pwd`/${ARCHIVE}.tar.bz2"
+  STAGE4_FILENAME="$(pwd)/${ARCHIVE}.tar.bz2"
 fi
 
 #Shifts pointer to read custom tar options
-shift;OPTIONS="$@"
+shift
+mapfile -t OPTIONS <<< "$@"
 
-if [ ${S_KERNEL} -eq 1 ]
+if ((S_KERNEL == 1))
 then
-  USER_EXCL+=" --exclude=${TARGET}usr/src/* "
-  if [ ${x86_64} -eq 1 ]
+  USER_EXCL+=("--exclude=${TARGET}usr/src/*")
+  if ((x86_64 == 1))
   then
-      USER_EXCL+=" --exclude=${TARGET}lib64/modules/* "
+      USER_EXCL+=("--exclude=${TARGET}lib64/modules/*")
   else
-      USER_EXCL+=" --exclude=${TARGET}lib/modules/* "
+      USER_EXCL+=("--exclude=${TARGET}lib/modules/*")
   fi
 fi
 
 
 # Excludes:
-EXCLUDES="\
---exclude=${TARGET}home/*/.bash_history \
---exclude=${TARGET}dev/* \
---exclude=${TARGET}var/tmp/* \
---exclude=${TARGET}media/* \
---exclude=${TARGET}mnt/*/* \
---exclude=${TARGET}proc/* \
---exclude=${TARGET}run/* \
---exclude=${TARGET}sys/* \
---exclude=${TARGET}tmp/* \
---exclude=${TARGET}var/lock/* \
---exclude=${TARGET}var/log/* \
---exclude=${TARGET}var/run/* \
---exclude=${TARGET}var/lib/docker/* "
+EXCLUDES=(
+    "--exclude=${TARGET}home/*/.bash_history"
+    "--exclude=${TARGET}dev/*"
+    "--exclude=${TARGET}var/tmp/*"
+    "--exclude=${TARGET}media/*"
+    "--exclude=${TARGET}mnt/*/*"
+    "--exclude=${TARGET}proc/*"
+    "--exclude=${TARGET}run/*"
+    "--exclude=${TARGET}sys/*"
+    "--exclude=${TARGET}tmp/*"
+    "--exclude=${TARGET}var/lock/*"
+    "--exclude=${TARGET}var/log/*"
+    "--exclude=${TARGET}var/run/*"
+    "--exclude=${TARGET}var/lib/docker/*"
+)
 
-EXCLUDES_DEFAULT_PORTAGE="\
- --exclude=${TARGET}var/db/repos/gentoo/* \
- --exclude=${TARGET}var/cache/distfiles/* \
- --exclude=${TARGET}usr/portage/*"
+EXCLUDES_DEFAULT_PORTAGE=(
+    "--exclude=${TARGET}var/db/repos/gentoo/*"
+    "--exclude=${TARGET}var/cache/distfiles/*"
+    "--exclude=${TARGET}usr/portage/*"
+)
 
-EXCLUDES+=$USER_EXCL
+EXCLUDES+=("${USER_EXCL[@]}")
 
-if [ "$TARGET" == "/" ]
+if [ "$TARGET" == '/' ]
 then
-  EXCLUDES+=" --exclude=${STAGE4_FILENAME#/}"
-  if [ ${HAS_PORTAGEQ} == 1 ]
+  EXCLUDES+=("--exclude=${STAGE4_FILENAME#/}")
+  if ((HAS_PORTAGEQ == 1))
   then
-	  EXCLUDES+=" --exclude=$(portageq get_repo_path / gentoo)/*"
-	  EXCLUDES+=" --exclude=$(portageq distdir)/*"
+	  EXCLUDES+=("--exclude=$(portageq get_repo_path / gentoo)/*")
+	  EXCLUDES+=("--exclude=$(portageq distdir)/*")
   else
-	  EXCLUDES+="${EXCLUDES_DEFAULT_PORTAGE}"
+	  EXCLUDES+=("${EXCLUDES_DEFAULT_PORTAGE[@]}")
   fi
 else
-	  EXCLUDES+="${EXCLUDES_DEFAULT_PORTAGE}"
+	  EXCLUDES+=("${EXCLUDES_DEFAULT_PORTAGE[@]}")
 fi
 
-if [ ${EXCLUDE_CONNMAN} -eq 1 ]
+if ((EXCLUDE_CONNMAN == 1))
 then
-  EXCLUDES+=" --exclude=${TARGET}var/lib/connman/*"
+  EXCLUDES+=("--exclude=${TARGET}var/lib/connman/*")
 fi
 
-if [ ${EXCLUDE_BOOT} -eq 1 ]
+if ((EXCLUDE_BOOT == 1))
 then
-  EXCLUDES+=" --exclude=${TARGET}boot/*"
+  EXCLUDES+=("--exclude=${TARGET}boot/*")
 fi
 
-if [ ${EXCLUDE_LOST} -eq 1 ]
+if ((EXCLUDE_LOST == 1))
 then
-  EXCLUDES+=" --exclude=lost+found"
+  EXCLUDES+=("--exclude=lost+found")
 fi
 
 # Generic tar options:
-TAR_OPTIONS="-cpP --ignore-failed-read --xattrs-include='*.*' --numeric-owner"
+TAR_OPTIONS=(-cpP --ignore-failed-read "--xattrs-include='*.*'" --numeric-owner)
 
-if [ ${PARALLEL} -eq 1 ] 
+if [ ${PARALLEL} -eq 1 ]
 then
-  if hash pbzip2 2>/dev/null; then
-    TAR_OPTIONS+=" --use-compress-prog=pbzip2"
+  if command -v pbzip2 &>/dev/null; then
+    TAR_OPTIONS+=("--use-compress-prog=pbzip2")
   else
-    echo "WARING: pbzip2 isn't installed, single-threaded compressing is used."
-    TAR_OPTIONS+=" -j"
+    echo "WARING: pbzip2 isn't installed, single-threaded compressing is used." >&2
+    TAR_OPTIONS+=("-j")
   fi
 else
-  TAR_OPTIONS+=" -j"
+  TAR_OPTIONS+=("-j")
 fi
 
 # if not in quiet mode, this message will be displayed:
-if [ "$AGREE" != "yes" ]
+if [[ "x$AGREE" != 'xyes' ]]
 then
   echo "Are you sure that you want to make a stage 4 tarball of the system"
   echo "located under the following directory?"
@@ -216,42 +220,40 @@ then
   echo "WARNING: since all data is saved by default the user should exclude all"
   echo "security- or privacy-related files and directories, which are not"
   echo "already excluded by mkstage4 options (such as -c), manually per cmdline."
-  echo "example: \$ `basename $0` -s /my-backup --exclude=/etc/ssh/ssh_host*"
+  echo "example: \$ $(basename "$0") -s /my-backup --exclude=/etc/ssh/ssh_host*"
   echo ""
   echo "COMMAND LINE PREVIEW:"
-  echo "tar $TAR_OPTIONS $EXCLUDES $OPTIONS -f $STAGE4_FILENAME ${TARGET}*"
-  if [ ${S_KERNEL} -eq 1 ]
+  echo "tar ${TAR_OPTIONS[*]} ${EXCLUDES[*]} ${OPTIONS[*]} -f $STAGE4_FILENAME ${TARGET}*"
+  if ((S_KERNEL == 1))
   then
     echo ""
-    echo  "tar $TAR_OPTIONS -f $STAGE4_FILENAME.ksrc ${TARGET}usr/src/linux-$(uname -r)*"
-    if [ ${x86_64} -eq 1 ]
+    echo  "tar ${TAR_OPTIONS[*]} -f $STAGE4_FILENAME.ksrc ${TARGET}usr/src/linux-$(uname -r)*"
+    if ((x86_64 == 1))
     then
         echo ""
-        echo  "tar $TAR_OPTIONS -f $STAGE4_FILENAME.kmod ${TARGET}lib64/modules/$(uname -r)*"
+        echo  "tar ${TAR_OPTIONS[*]} -f $STAGE4_FILENAME.kmod ${TARGET}lib64/modules/$(uname -r)*"
     else
         echo ""
-        echo  "tar $TAR_OPTIONS -f $STAGE4_FILENAME.kmod ${TARGET}lib/modules/$(uname -r)*"
+        echo  "tar ${TAR_OPTIONS[*]} -f $STAGE4_FILENAME.kmod ${TARGET}lib/modules/$(uname -r)*"
     fi
   fi
   echo ""
   echo -n "Type \"yes\" to continue or anything else to quit: "
-  read AGREE
+  read -r AGREE
 fi
 
 # start stage4 creation:
 if [ "$AGREE" == "yes" ]
 then
-  tar $TAR_OPTIONS $EXCLUDES $OPTIONS -f $STAGE4_FILENAME ${TARGET}*
+  tar "${TAR_OPTIONS[@]}" "${EXCLUDES[@]}" "${OPTIONS[@]}" -f "$STAGE4_FILENAME" ${TARGET}*
   if [ ${S_KERNEL} -eq 1 ]
   then
-    tar $TAR_OPTIONS -f $STAGE4_FILENAME.ksrc ${TARGET}usr/src/linux-$(uname -r)*
+    tar "${TAR_OPTIONS[@]}" -f "$STAGE4_FILENAME.ksrc" "${TARGET}usr/src/linux-$(uname -r)"*
     if [ ${x86_64} -eq 1 ]
     then
-        tar $TAR_OPTIONS -f $STAGE4_FILENAME.kmod ${TARGET}lib64/modules/$(uname -r)*
+        tar "${TAR_OPTIONS[@]}" -f "$STAGE4_FILENAME.kmod" "${TARGET}lib64/modules/$(uname -r)"*
     else
-        tar $TAR_OPTIONS -f $STAGE4_FILENAME.kmod ${TARGET}lib/modules/$(uname -r)*
+        tar "${TAR_OPTIONS[@]}" -f "$STAGE4_FILENAME.kmod" "${TARGET}lib/modules/$(uname -r)"*
     fi
   fi
 fi
-
-exit 0


### PR DESCRIPTION
* Use arrays for lists of items
* Do not use legacy backticks
* Add quotes where they should be
* Remove unnecessary `exit 0`