### PR TITLE
-k test cases: bug fix & additional test cases

### DIFF
--- a/tests/0001.bats
+++ b/tests/0001.bats
@@ -6,10 +6,10 @@ setup() {
     f test/.hiddenfile
     f test/usr/bin/ping
     f test/usr/bin/lost+found
-    f test/usr/src/linux-"$test_uname"/.config
-    f test/usr/src/linux-"$test_uname"/vmlinux
-    f test/lib/modules/"$test_uname"/mod.ko
-    f test/lib64/modules/"$test_uname"/mod.ko
+    f test/usr/src/linux-"$TEST_UNAME"/.config
+    f test/usr/src/linux-"$TEST_UNAME"/vmlinux
+    f test/lib/modules/"$TEST_UNAME"/mod.ko
+    f test/lib64/modules/"$TEST_UNAME"/mod.ko
     f test/dev/sda
     f test/proc/cpuinfo
     f test/run/pid
@@ -43,19 +43,19 @@ teardown() {
 }
 
 @test "/usr/src/linux-uname/.config is included" {
-    assert_tar_includes test/usr/src/linux-"$test_uname"/.config
+    assert_tar_includes test/usr/src/linux-"$TEST_UNAME"/.config
 }
 
 @test "/usr/src/linux-uname/vmlinux is included" {
-    assert_tar_includes test/usr/src/linux-"$test_uname"/vmlinux
+    assert_tar_includes test/usr/src/linux-"$TEST_UNAME"/vmlinux
 }
 
 @test "/lib/modules/uname/mod.ko is included" {
-    assert_tar_includes test/lib/modules/"$test_uname"/mod.ko
+    assert_tar_includes test/lib/modules/"$TEST_UNAME"/mod.ko
 }
 
 @test "/lib64/modules/uname/mod.ko is included" {
-    assert_tar_includes test/lib64/modules/"$test_uname"/mod.ko
+    assert_tar_includes test/lib64/modules/"$TEST_UNAME"/mod.ko
 }
 
 @test "/dev/* is excluded" {

--- a/tests/0003.bats
+++ b/tests/0003.bats
@@ -4,10 +4,14 @@ load test_helper
 
 setup() {
     f test/usr/bin/ping
-    f test/usr/src/linux-"$test_uname"/.config
-    f test/usr/src/linux-"$test_uname"/vmlinux
-    f test/lib/modules/"$test_uname"/mod.ko
-    f test/lib64/modules/"$test_uname"/mod.ko
+    f test/usr/src/linux-"$TEST_UNAME"/.config
+    f test/usr/src/linux-"$TEST_UNAME"/vmlinux
+    f test/usr/src/linux-different-uname/.config
+    f test/usr/src/linux-different-uname/vmlinux
+    f test/lib/modules/"$TEST_UNAME"/mod.ko
+    f test/lib64/modules/"$TEST_UNAME"/mod.ko
+    f test/lib/modules/different-uname/mod.ko
+    f test/lib64/modules/different-uname/mod.ko
     mkstage4.sh -k -q -t test test
 }
 
@@ -19,36 +23,68 @@ teardown() {
     assert_tar_includes test/usr/bin/ping
 }
 
-@test "/usr/src/linux-uname/.config is excluded" {
-    assert_tar_excludes test/usr/src/linux-"$test_uname"/.config
+@test "/usr/src/ is included" {
+    assert_tar_includes test/usr/src/
 }
 
-@test "/usr/src/linux-uname/vmlinux is excluded" {
-    assert_tar_excludes test/usr/src/linux-"$test_uname"/vmlinux
+@test "/lib/modules/ is included" {
+    assert_tar_includes test/lib/modules/
 }
 
-@test "/lib/modules/uname/mod.ko is excluded" {
-    assert_tar_excludes test/lib/modules/"$test_uname"/mod.ko
+@test "/lib64/modules/ is included" {
+    assert_tar_includes test/lib64/modules/
 }
 
-@test "/lib64/modules/uname/mod.ko is excluded" {
-    assert_tar_excludes test/lib64/modules/"$test_uname"/mod.ko
+@test "/usr/src/linux-$TEST_UNAME/ is excluded" {
+    assert_tar_excludes test/usr/src/linux-"$TEST_UNAME"/
 }
 
-@test "/usr/src/linux-uname/.config is included" {
-    assert_tar_includes test/usr/src/linux-"$test_uname"/.config test.tar.bz2.ksrc
+@test "/usr/src/linux-different-uname/ is excluded" {
+    assert_tar_excludes test/usr/src/linux-different-uname/
 }
 
-@test "/usr/src/linux-uname/vmlinux is included" {
-    assert_tar_includes test/usr/src/linux-"$test_uname"/vmlinux test.tar.bz2.ksrc
+@test "/lib/modules/$TEST_UNAME/ is excluded" {
+    assert_tar_excludes test/lib/modules/"$TEST_UNAME"/
 }
 
-@test "/lib/modules/uname/mod.ko is included" {
-    assert_tar_includes test/lib/modules/"$test_uname"/mod.ko test.tar.bz2.kmod
+@test "/lib/modules/different-uname/ is excluded" {
+    assert_tar_excludes test/lib/modules/different-uname/
 }
 
-@test "/lib64/modules/uname/mod.ko is included" {
-    assert_tar_includes test/lib64/modules/"$test_uname"/mod.ko test.tar.bz2.kmod
+@test "/lib64/modules/$TEST_UNAME/ is excluded" {
+    assert_tar_excludes test/lib64/modules/"$TEST_UNAME"/
+}
+
+@test "/lib64/modules/different-uname/ is excluded" {
+    assert_tar_excludes test/lib64/modules/different-uname/
+}
+
+@test "/usr/src/linux-$TEST_UNAME/.config is included in ksrc" {
+    assert_tar_includes test/usr/src/linux-"$TEST_UNAME"/.config test.tar.bz2.ksrc
+}
+
+@test "/usr/src/linux-$TEST_UNAME/vmlinux is included in ksrc" {
+    assert_tar_includes test/usr/src/linux-"$TEST_UNAME"/vmlinux test.tar.bz2.ksrc
+}
+
+@test "/usr/src/linux-different-uname/ is excluded in ksrc" {
+    assert_tar_excludes test/usr/src/linux-different-uname/ test.tar.bz2.ksrc
+}
+
+@test "/lib/modules/$TEST_UNAME/mod.ko is included in kmod" {
+    assert_tar_includes test/lib/modules/"$TEST_UNAME"/mod.ko test.tar.bz2.kmod
+}
+
+@test "/lib64/modules/$TEST_UNAME/mod.ko is included in kmod" {
+    assert_tar_includes test/lib64/modules/"$TEST_UNAME"/mod.ko test.tar.bz2.kmod
+}
+
+@test "/lib/modules/different-uname/ is excluded in kmod" {
+    assert_tar_excludes test/lib/modules/different-uname/ test.tar.bz2.kmod
+}
+
+@test "/lib64/modules/different-uname/ is excluded in kmod" {
+    assert_tar_excludes test/lib64/modules/different-uname/ test.tar.bz2.kmod
 }
 
 # vim: ft=bash

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -3,8 +3,9 @@
 test_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export PATH="$test_directory/..:$PATH"
 
-test_uname="test-uname"
-uname() { echo "$test_uname"; }
+# export so that uname hook in mkstage4.sh has access to var
+export TEST_UNAME="test-uname"
+uname() { echo "$TEST_UNAME"; }
 export -f uname
 
 # bypasses mkstage4.sh root check


### PR DESCRIPTION
I didn't export a var causing the uname hook to evaluate to the empty string during tests.

- Fixed that bug
- Added additional test cases for `-k` option.