### PR TITLE
Use star mark to expand COMP_OPTIONS

### DIFF
--- a/mkstage4.sh
+++ b/mkstage4.sh
@@ -250,7 +250,7 @@ TAR_OPTIONS=(
 	--ignore-failed-read
 	"--xattrs-include='*.*'"
 	--numeric-owner
-	"--use-compress-prog=\"${COMP_OPTIONS[@]}\""
+	"--use-compress-prog=\"${COMP_OPTIONS[*]}\""
 	)
 
 # if not in quiet mode, this message will be displayed:


### PR DESCRIPTION
When using mkstage4 script  with `-C xz` option in command line, I encountered some errors:
```
tar: 0": Cannot stat: No such file or directory
tar: Error is not recoverable: exiting now
```
After that, I looked into the script code, inserted `set -x` at the head line, and found out the final tar command executed by shell has became as follows:
```
tar -cpP --ignore-failed-read '--xattrs-include='\''*.*'\''' --numeric-owner '--use-compress-prog="/usr/bin/xz' '-T0"' '--exclude=/dev/*' '--exclude=/var/tmp/*' '--exclude=/media/*' '--exclude=/mnt/*/*' '--exclude=/proc/*' '--exclude=/run/*' '--exclude=/sys/*' '--exclude=/tmp/*' '--exclude=/var/lock/*' '--exclude=/var/log/*' '--exclude=/var/run/*' '--exclude=/var/lib/docker/*' --exclude=/home/an9wer/newstage5.tar.xz '--exclude=/var/db/repos/gentoo/*' '--exclude=/var/cache/distfiles/*' '--exclude=/home/*/.bash_history' --exclude=/root/.bash_history '--exclude=/var/lib/connman/*' --exclude=lost+found -f /root/mystage4.tar.xz /
```
The problems  in above command are `'--use-compress-prog="/usr/bin/xz'` and `'-T0"'` options. The `'-T0"'` is treated as the option of tar not xz, so the two options should be combined into one as `'--use-compress-prog="/usr/bin/xz -T0"'`.

Finally, I found the reason causing this problem is the bad use of @ to expand COMP_OPTIONS, and here is my prove:
```sh
$ COMP_OPTIONS=("/usr/bin/xz" "-T0")
$
$ # use @ to expand COMP_OPTIONS
$ TAR_OPTIONS=("--use-compress-prog=\"${COMP_OPTIONS[@]}\"")
$ declare -p TAR_OPTIONS
declare -a TAR_OPTIONS=([0]="--use-compress-prog=\"/usr/bin/xz" [1]="-T0\"")
$
$ # use * to expand COMP_OPTIONS
$ TAR_OPTIONS=("--use-compress-prog=\"${COMP_OPTIONS[*]}\"")
$ declare -p TAR_OPTIONS
declare -a TAR_OPTIONS=([0]="--use-compress-prog=\"/usr/bin/xz -T0\"")

```
