### PR TITLE
Do not backup lx{c,d} folders

### DIFF
--- a/mkstage4.sh
+++ b/mkstage4.sh
@@ -191,6 +191,9 @@ EXCLUDES=(
 	"--exclude=${TARGET}var/lock/*"
 	"--exclude=${TARGET}var/log/*"
 	"--exclude=${TARGET}var/run/*"
+	"--exclude=${TARGET}var/lib/lxc/*"
+	"--exclude=${TARGET}var/lib/lxd/*"
+	"--exclude=${TARGET}var/lib/lxcfs/*"
 	"--exclude=${TARGET}var/lib/docker/*"
 )
 


### PR DESCRIPTION
LX{C,D} folders are directly connected to the host so, during the backup, they change even if the the container is stopped. My best suggestion is to unmerge lxd and related things, reboot and then do the backup.