### PR TITLE
Fixed error in README.md regarding usage of the zstd compression type

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,6 @@ tar -I unpigz -xvf archive_name.tar.gz --xattrs-include='*.*' --numeric-owner
 * `-C lzo`:
   * **[lzop](https://www.lzop.org/)** - in Portage as **[app-arch/lzop](https://packages.gentoo.org/packages/app-arch/lzop)**, (parallel)
 
-* `-C zstd`:
+* `-C zst`:
   * **[zstd](https://facebook.github.io/zstd/)** - in Portage as **[app-arch/zstd](https://packages.gentoo.org/packages/app-arch/zstd)**, (parallel)
 


### PR DESCRIPTION
The functional argument for using zstd at the moment in `mkstage4` is `-C zst` not `-C zstd`.

This is due the fact that the extension for zstd compressed files is `.zst`.
To account for this, the script could be changed to accept `zstd` as compression type (`-C`), because `zstd` is probably the most commonly referred keyword for zstd compression, see e.g. `tar --zstd`.

But for now the script works with `-C zst`, so this should be reflected in the documentation/README.